### PR TITLE
Update nom to version 7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ version = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-nom = "6"
+nom = "7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -886,17 +886,11 @@ mod parser {
     }
 
     fn unsigned_integer_32(input: &str) -> IResult<&str, u32> {
-        context(
-            "unsigned_integer_32",
-            map_res(digit0, |s: &str| s.parse::<u32>()),
-        )(input)
+        context("unsigned_integer_32", map_res(digit0, str::parse::<u32>))(input)
     }
 
     fn unsigned_integer_64(input: &str) -> IResult<&str, u64> {
-        context(
-            "unsigned_integer_64",
-            map_res(digit0, |s: &str| s.parse::<u64>()),
-        )(input)
+        context("unsigned_integer_64", map_res(digit0, str::parse::<u64>))(input)
     }
 
     #[cfg(test)]


### PR DESCRIPTION
As of Rust 1.69.0, a notice appears when compiling a project containing this crate stating that code in `nom v6.1.2` will be rejected in a future version of Rust. This PR updates the version of nom to 7, fixing the issue. (Additionally, it also removes two now-unnecessary closures). 